### PR TITLE
Coordinated animationとConnectedAnimationConfigurationに対応

### DIFF
--- a/Avalonia.ConnectedAnimation.sln
+++ b/Avalonia.ConnectedAnimation.sln
@@ -3,9 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Avalonia.ConnectedAnimation", "Avalonia.ConnectedAnimation\Avalonia.ConnectedAnimation.csproj", "{9379E213-FD07-4B6B-80D9-BB0062AE57BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.ConnectedAnimation", "Avalonia.ConnectedAnimation\Avalonia.ConnectedAnimation.csproj", "{9379E213-FD07-4B6B-80D9-BB0062AE57BB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp", "SampleApp\SampleApp.csproj", "{8A1535FB-B1E2-4731-8726-DA95E76351B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleApp", "SampleApp\SampleApp.csproj", "{8A1535FB-B1E2-4731-8726-DA95E76351B8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject1", "TestProject1\TestProject1.csproj", "{37BC7CD6-4A65-42A4-A96A-4F3071385194}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{8A1535FB-B1E2-4731-8726-DA95E76351B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A1535FB-B1E2-4731-8726-DA95E76351B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8A1535FB-B1E2-4731-8726-DA95E76351B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37BC7CD6-4A65-42A4-A96A-4F3071385194}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37BC7CD6-4A65-42A4-A96A-4F3071385194}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37BC7CD6-4A65-42A4-A96A-4F3071385194}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37BC7CD6-4A65-42A4-A96A-4F3071385194}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Avalonia.ConnectedAnimation/AnimationDirection.cs
+++ b/Avalonia.ConnectedAnimation/AnimationDirection.cs
@@ -1,0 +1,21 @@
+﻿namespace Avalonia.ConnectedAnimation;
+
+[Flags]
+internal enum AnimationDirection
+{
+    None,
+
+    // 上がる ⤴
+    Upper = 1,
+
+    // 下がる ⤵
+    Lower = 1 << 1,
+
+    Left = 1 << 2,
+    Right = 1 << 3,
+
+    LeftUpper = Left | Upper,
+    RightUpper = Right | Upper,
+    RightLower = Right | Lower,
+    LeftLower = Left | Lower,
+}

--- a/Avalonia.ConnectedAnimation/BasicConnectedAnimationConfiguration.cs
+++ b/Avalonia.ConnectedAnimation/BasicConnectedAnimationConfiguration.cs
@@ -1,0 +1,21 @@
+﻿using Avalonia.Animation.Easings;
+
+namespace Avalonia.ConnectedAnimation;
+
+public sealed class BasicConnectedAnimationConfiguration : ConnectedAnimationConfiguration
+{
+    public override ICurve GetCurve(Rect start, Rect end, ICurve defaultCurve)
+    {
+        return defaultCurve;
+    }
+
+    public override TimeSpan GetDuration(Rect start, Rect end, TimeSpan defaultDuration)
+    {
+        return defaultDuration;
+    }
+
+    public override Easing GetEasing(Rect start, Rect end, Easing defaultEasing)
+    {
+        return defaultEasing;
+    }
+}

--- a/Avalonia.ConnectedAnimation/BezierCurveQuadric.cs
+++ b/Avalonia.ConnectedAnimation/BezierCurveQuadric.cs
@@ -1,0 +1,114 @@
+﻿// https://github.com/opentk/opentk/blob/131db3c812584aad52325c67675ab32ab8c9ddc2/src/OpenTK.Mathematics/Vector/Vector2.cs
+
+using System.Diagnostics.Contracts;
+using System.Numerics;
+
+namespace Avalonia.ConnectedAnimation;
+
+internal sealed class BezierCurveQuadric : ICurve
+{
+    public Vector StartAnchor;
+
+    public Vector EndAnchor;
+
+    public Vector ControlPoint;
+
+    public double Parallel;
+
+    public BezierCurveQuadric()
+    {
+        StartAnchor = Vector.Zero;
+        EndAnchor = Vector.One;
+        ControlPoint = new Vector(0, 0.5);
+        Parallel = 0.0;
+    }
+
+    public BezierCurveQuadric(Vector startAnchor, Vector endAnchor, Vector controlPoint)
+    {
+        StartAnchor = startAnchor;
+        EndAnchor = endAnchor;
+        ControlPoint = controlPoint;
+        Parallel = 0.0;
+    }
+
+    public BezierCurveQuadric(double parallel, Vector startAnchor, Vector endAnchor, Vector controlPoint)
+    {
+        Parallel = parallel;
+        StartAnchor = startAnchor;
+        EndAnchor = endAnchor;
+        ControlPoint = controlPoint;
+    }
+
+    public Vector CalculatePoint(double progress)
+    {
+        static Vector PerpendicularRight(Vector point)
+        {
+            // https://github.com/opentk/opentk/blob/131db3c812584aad52325c67675ab32ab8c9ddc2/src/OpenTK.Mathematics/Vector/Vector2.cs#L144
+            return new Vector(point.Y, -point.X);
+        }
+
+        var c = 1.0 - progress;
+        var r = new Vector
+        (
+            (c * c * StartAnchor.X) + (2 * progress * c * ControlPoint.X) + (progress * progress * EndAnchor.X),
+            (c * c * StartAnchor.Y) + (2 * progress * c * ControlPoint.Y) + (progress * progress * EndAnchor.Y)
+        );
+
+        if (Parallel == 0.0)
+        {
+            return r;
+        }
+
+        Vector perpendicular;
+
+        if (progress == 0.0)
+        {
+            perpendicular = ControlPoint - StartAnchor;
+        }
+        else
+        {
+            perpendicular = r - CalculatePointOfDerivative(progress);
+        }
+
+        return r + (PerpendicularRight(perpendicular.Normalize()) * Parallel);
+    }
+
+    private Vector CalculatePointOfDerivative(double t)
+    {
+        var r = new Vector
+        (
+            ((1.0f - t) * StartAnchor.X) + (t * ControlPoint.X),
+            ((1.0f - t) * StartAnchor.Y) + (t * ControlPoint.Y)
+        );
+
+        return r;
+    }
+
+    public double CalculateLength(double precision)
+    {
+        var length = 0.0;
+        var old = CalculatePoint(0.0);
+
+        for (var i = precision; i < 1.0 + precision; i += precision)
+        {
+            var n = CalculatePoint(i);
+            length += (n - old).Length;
+            old = n;
+        }
+
+        return length;
+    }
+
+    public Vector CalculatePosition(Rect start, Rect end, double progress)
+    {
+        StartAnchor = start.Position;
+        EndAnchor = end.Position;
+
+        var centerX = ((end.X - start.X) * 0.5) + start.X;
+        var bottom = Math.Max(start.Bottom, end.Bottom) + Math.Min(start.Height, end.Height) / 2;
+
+        ControlPoint = new Vector(centerX, bottom);
+
+        return CalculatePoint(progress);
+    }
+}

--- a/Avalonia.ConnectedAnimation/ConnectedAnimation.cs
+++ b/Avalonia.ConnectedAnimation/ConnectedAnimation.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
+using Avalonia.Media.Imaging;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -13,21 +14,34 @@ public class ConnectedAnimation
 {
     private readonly Control _source;
     private readonly EventHandler _reportCompleted;
+    private readonly ConnectedAnimationService _service;
     private readonly Rect _sourceBounds;
+    private readonly RenderTargetBitmap _sourceImage;
+    private bool _isDisposed;
 
-    internal ConnectedAnimation(string key, Control source, EventHandler completed)
+    internal ConnectedAnimation(string key, Control source, EventHandler completed, ConnectedAnimationService service)
     {
         Key = key ?? throw new ArgumentNullException(nameof(key));
         _source = source ?? throw new ArgumentNullException(nameof(source));
         _reportCompleted = completed ?? throw new ArgumentNullException(nameof(completed));
-
-        _sourceBounds = source.AbsoluteBounds();
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+        _sourceBounds = source.AbsoluteBounds().Inflate(source.Margin);
+        // Pre render
+        source.Measure(Size.Infinity);
+        source.Arrange(new Rect(source.DesiredSize));
+        _sourceImage = new RenderTargetBitmap(PixelSize.FromSize(source.DesiredSize, 1));
+        _sourceImage.Render(source);
     }
 
     public string Key { get; }
 
+    public ConnectedAnimationConfiguration Configuration { get; set; } = new GravityConnectedAnimationConfiguration();
+
     public void Cancel()
     {
+        _sourceImage.Dispose();
+        _isDisposed = true;
+
         _reportCompleted?.Invoke(this, EventArgs.Empty);
     }
 
@@ -46,7 +60,7 @@ public class ConnectedAnimation
         {
             throw new ArgumentNullException(nameof(coordinatedElements));
         }
-        if (Equals(_source, destination))
+        if (Equals(_source, destination) || _isDisposed)
         {
             return false;
         }
@@ -60,18 +74,17 @@ public class ConnectedAnimation
             renderRoot = destination.GetVisualRoot();
         }
 
-        var connectionHost = new ConnectedVisual(_sourceBounds, destination);
-        var direction = Helper.GetDirection(_sourceBounds, connectionHost.DestinationBounds);
+        var connectionHost = new ConnectedVisual(_sourceImage, _sourceBounds, destination, _service.DefaultCurve, Configuration);
         var coordinatedHosts = coordinatedElements
-            .Select(x => new CoordinatedVisual(connectionHost, x, direction))
+            .Select(x => new CoordinatedVisual(connectionHost, x, _service.DefaultCurve, Configuration))
             .ToArray();
 
         var adorner = ConnectedAnimationAdorner.FindFrom(destination, renderRoot);
         adorner.Children.Add(connectionHost);
         adorner.Children.AddRange(coordinatedHosts);
 
-        var duration = TimeSpan.FromMilliseconds(500);
-        var easing = new CircularEaseInOut();
+        var duration = Configuration.GetDuration(_sourceBounds, connectionHost.DestinationBounds, _service.DefaultDuration);
+        var easing = Configuration.GetEasing(_sourceBounds, connectionHost.DestinationBounds, _service.DefaultEasingFunction);
 
         var tasks = Task.WhenAll(coordinatedHosts.Select(x => x.RunAnimation(duration, easing, TimeSpan.Zero)));
         await connectionHost.RunAnimation(duration, easing);

--- a/Avalonia.ConnectedAnimation/ConnectedAnimationConfiguration.cs
+++ b/Avalonia.ConnectedAnimation/ConnectedAnimationConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using Avalonia.Animation.Easings;
+
+namespace Avalonia.ConnectedAnimation;
+
+public abstract class ConnectedAnimationConfiguration
+{
+    public abstract Easing GetEasing(Rect start, Rect end, Easing defaultEasing);
+
+    public abstract TimeSpan GetDuration(Rect start, Rect end, TimeSpan defaultDuration);
+
+    public abstract ICurve GetCurve(Rect start, Rect end, ICurve defaultCurve);
+}

--- a/Avalonia.ConnectedAnimation/ConnectedAnimationService.cs
+++ b/Avalonia.ConnectedAnimation/ConnectedAnimationService.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia.Animation.Easings;
+using Avalonia.Controls;
 using Avalonia.VisualTree;
 
 namespace Avalonia.ConnectedAnimation;
@@ -13,6 +14,21 @@ public class ConnectedAnimationService : AvaloniaObject
     private ConnectedAnimationService()
     {
     }
+
+    // 450
+    // 750
+    public TimeSpan DefaultDuration { get; set; } = TimeSpan.FromMilliseconds(300);
+
+    // https://easings.net/
+    //var easing = new SplineEasing(0, .79, 1, -0.18);
+    //var easing = new SplineEasing(0, 0, 1, 0);
+    //var easing = new SplineEasing(0, 0.83, 1, 0.17);
+    //var easing = new QuinticEaseInOut();
+    //var easing = new ExponentialEaseInOut();
+    //var easing = new CircularEaseInOut();
+    public Easing DefaultEasingFunction { get; set; } = new SplineEasing(0.1, 0.9, 0.2, 1);
+
+    public ICurve DefaultCurve { get; set; } = new LinearCurve();
 
     public void PrepareToAnimate(string key, Control source)
     {
@@ -30,7 +46,7 @@ public class ConnectedAnimationService : AvaloniaObject
             throw new ArgumentException("The specified key is already prepared for animation and should not be prepared repeatedly.", nameof(key));
         }
 
-        info = new ConnectedAnimation(key, source, OnAnimationCompleted);
+        info = new ConnectedAnimation(key, source, OnAnimationCompleted, this);
         _connectingAnimations.Add(key, info);
     }
 

--- a/Avalonia.ConnectedAnimation/CoordinatedVisual.cs
+++ b/Avalonia.ConnectedAnimation/CoordinatedVisual.cs
@@ -1,0 +1,196 @@
+﻿using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Avalonia.VisualTree;
+
+namespace Avalonia.ConnectedAnimation;
+
+internal sealed class CoordinatedVisual : Control
+{
+    public static readonly DirectProperty<CoordinatedVisual, double> ProgressProperty = ConnectedVisual.ProgressProperty.AddOwner<CoordinatedVisual>(
+        o => o.Progress,
+        (o, v) => o.Progress = v);
+    private readonly ConnectedVisual _connectedVisual;
+    private readonly Control _control;
+    private readonly AnimationDirection _direction;
+    private readonly Brush _destinationBrush;
+    private readonly Rect _sourceBounds;
+    private readonly Rect _destinationBounds;
+    private double _progress = 0.0;
+    private readonly RenderTargetBitmap _destinationImage;
+    private readonly RelativeLocation _location;
+
+    static CoordinatedVisual()
+    {
+        AffectsRender<CoordinatedVisual>(ProgressProperty);
+    }
+
+    public CoordinatedVisual(ConnectedVisual connectedVisual, Control control, AnimationDirection direction)
+    {
+        _connectedVisual = connectedVisual;
+        _control = control ?? throw new ArgumentNullException(nameof(control));
+        _direction = direction;
+
+        // Store PreviousArrange
+        var prevArrange = ((ILayoutable)control).PreviousArrange;
+
+        _destinationBounds = control.AbsoluteBounds();
+        _location = Helper.GetRelativeLocation(connectedVisual.DestinationBounds, _destinationBounds);
+
+        // Find the optimal sourceBounds.
+        {
+            var width = _destinationBounds.Width;
+            var height = _destinationBounds.Height;
+
+            double x = 0, y = 0;
+            var pos = _destinationBounds.Position - connectedVisual.DestinationBounds.Position;
+            x = connectedVisual.SourceBounds.X + pos.X;
+            y = connectedVisual.SourceBounds.Y + pos.Y;
+            // 170
+
+            //switch (_location)
+            //{
+            //    case RelativeLocation.Above:
+            //        if (direction.HasFlag(AnimationDirection.Lower))
+            //        {
+            //            y = connectedVisual.DestinationBounds.Top;
+            //        }
+
+            //        if (direction.HasFlag(AnimationDirection.Upper))
+            //        {
+            //            y = connectedVisual.SourceBounds.Top;
+            //        }
+
+            //        x = 0;
+            //        break;
+            //    case RelativeLocation.Below:
+            //        if (direction.HasFlag(AnimationDirection.Lower))
+            //        {
+            //            y = connectedVisual.DestinationBounds.Bottom;
+            //        }
+
+            //        if (direction.HasFlag(AnimationDirection.Upper))
+            //        {
+            //            y = connectedVisual.SourceBounds.Bottom;
+            //        }
+
+            //        x = 0;
+            //        break;
+            //    case RelativeLocation.Right:
+            //        if (direction.HasFlag(AnimationDirection.Left))
+            //        {
+            //            x = connectedVisual.SourceBounds.Right;
+            //        }
+
+            //        if (direction.HasFlag(AnimationDirection.Right))
+            //        {
+            //            x = connectedVisual.DestinationBounds.Right;
+            //        }
+
+            //        y = 0;
+            //        break;
+            //    case RelativeLocation.Left:
+            //        if (direction.HasFlag(AnimationDirection.Left))
+            //        {
+            //            x = connectedVisual.SourceBounds.Left;
+            //        }
+
+            //        if (direction.HasFlag(AnimationDirection.Right))
+            //        {
+            //            x = connectedVisual.DestinationBounds.Left;
+            //        }
+
+            //        y = 0;
+            //        break;
+            //    default:
+            //        break;
+            //}
+
+            _sourceBounds = new Rect(x, y, width, height);
+        }
+
+        // Pre render
+        control.Measure(Size.Infinity);
+        control.Arrange(new Rect(control.DesiredSize));
+        _destinationImage = new RenderTargetBitmap(PixelSize.FromSize(control.DesiredSize, 1));
+        _destinationImage.Render(control);
+        if (prevArrange.HasValue)
+        {
+            control.Arrange(prevArrange.Value);
+        }
+        else
+        {
+            _control.InvalidateArrange();
+        }
+
+        _destinationBrush = new ImageBrush(_destinationImage)
+        {
+            Stretch = Stretch.Fill,
+            BitmapInterpolationMode = BitmapInterpolationMode.HighQuality
+        };
+
+
+    }
+
+    public double Progress
+    {
+        get => _progress;
+        set => SetAndRaise(ProgressProperty, ref _progress, Math.Clamp(value, 0, 1));
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        var bounds = new Rect(
+            (_destinationBounds.Left - _sourceBounds.Left) * _progress + _sourceBounds.Left,
+            (_destinationBounds.Top - _sourceBounds.Top) * _progress + _sourceBounds.Top,
+            (_destinationBounds.Width - _sourceBounds.Width) * _progress + _sourceBounds.Width,
+            (_destinationBounds.Height - _sourceBounds.Height) * _progress + _sourceBounds.Height);
+
+        using (context.PushPreTransform(Matrix.CreateTranslation(bounds.X, bounds.Y)))
+        {
+            bounds = bounds.WithX(0).WithY(0);
+
+            _destinationBrush.Opacity = _progress;
+            context.DrawRectangle(_destinationBrush, null, bounds);
+        }
+    }
+
+    public async Task RunAnimation(TimeSpan duration, Easing easing, TimeSpan delay)
+    {
+        var animation = new Animation.Animation()
+        {
+            Duration = duration,
+            Delay = delay,
+            Easing = easing,
+            Children =
+            {
+                new KeyFrame()
+                {
+                    Cue = new Cue(0),
+                    Setters =
+                    {
+                        new Setter(ProgressProperty, 0.0)
+                    }
+                },
+                new KeyFrame()
+                {
+                    Cue = new Cue(1),
+                    Setters =
+                    {
+                        new Setter(ProgressProperty, 1.0)
+                    }
+                }
+            }
+        };
+
+        var storedOpacity = _control.Opacity;
+        _control.Opacity = 0;
+        await animation.RunAsync(this, null);
+
+        _control.Opacity = storedOpacity;
+    }
+}

--- a/Avalonia.ConnectedAnimation/DirectConnectedAnimationConfiguration.cs
+++ b/Avalonia.ConnectedAnimation/DirectConnectedAnimationConfiguration.cs
@@ -1,0 +1,25 @@
+﻿using Avalonia.Animation.Easings;
+
+namespace Avalonia.ConnectedAnimation;
+
+public sealed class DirectConnectedAnimationConfiguration : ConnectedAnimationConfiguration
+{
+    private static readonly Easing s_easing = new SplineEasing(0.1, 0.9, 0.2, 1);
+
+    public override ICurve GetCurve(Rect start, Rect end, ICurve defaultCurve)
+    {
+        return defaultCurve;
+    }
+
+    public override TimeSpan GetDuration(Rect start, Rect end, TimeSpan defaultDuration)
+    {
+        var length = ((Vector)(start.TopLeft - end.TopLeft)).Length;
+
+        return TimeSpan.FromMilliseconds(Math.Max(length, 150));
+    }
+
+    public override Easing GetEasing(Rect start, Rect end, Easing defaultEasing)
+    {
+        return s_easing;
+    }
+}

--- a/Avalonia.ConnectedAnimation/GravityConnectedAnimationConfiguration.cs
+++ b/Avalonia.ConnectedAnimation/GravityConnectedAnimationConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using Avalonia.Animation.Easings;
+
+namespace Avalonia.ConnectedAnimation;
+
+public sealed class GravityConnectedAnimationConfiguration : ConnectedAnimationConfiguration
+{
+    public override ICurve GetCurve(Rect start, Rect end, ICurve defaultCurve)
+    {
+        return new BezierCurveQuadric();
+    }
+
+    public override TimeSpan GetDuration(Rect start, Rect end, TimeSpan defaultDuration)
+    {
+        var length = ((Vector)(start.TopLeft - end.TopLeft)).Length + Math.Min(start.Height, end.Height) / 2;
+
+        return TimeSpan.FromMilliseconds(Math.Clamp(length, 170, 400));
+    }
+
+    public override Easing GetEasing(Rect start, Rect end, Easing defaultEasing)
+    {
+        return new LinearEasing();
+    }
+}

--- a/Avalonia.ConnectedAnimation/Helper.cs
+++ b/Avalonia.ConnectedAnimation/Helper.cs
@@ -1,4 +1,6 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Utilities;
 using Avalonia.VisualTree;
 
 namespace Avalonia.ConnectedAnimation;
@@ -26,5 +28,107 @@ public static class Helper
         control.AttachedToVisualTree += OnAttachedToVisualTree;
 
         return tcs.Task;
+    }
+
+    internal static AnimationDirection GetDirection(Rect source, Rect destination)
+    {
+        var sourceCenter = source.Center;
+        var destinationCenter = destination.Center;
+
+        if (sourceCenter.NearlyEquals(destinationCenter))
+        {
+            return AnimationDirection.None;
+        }
+        else if (sourceCenter.X > destinationCenter.X)
+        {
+            // 右に移動
+            if (sourceCenter.Y > destinationCenter.Y)
+            {
+                // 下に移動
+                return AnimationDirection.RightLower;
+            }
+            else
+            {
+                // 上に移動
+                return AnimationDirection.RightUpper;
+            }
+        }
+        else
+        {
+            // 左に移動
+            if (sourceCenter.Y > destinationCenter.Y)
+            {
+                // 下に移動
+                return AnimationDirection.LeftLower;
+            }
+            else
+            {
+                // 上に移動
+                return AnimationDirection.LeftUpper;
+            }
+        }
+    }
+
+    internal static double NormalizeRadian(double radian)
+    {
+        const double TWO_PI = 2 * Math.PI;
+
+        double normalized = radian % TWO_PI;
+        normalized = (normalized + TWO_PI) % TWO_PI;
+        return normalized <= Math.PI ? normalized : normalized - TWO_PI;
+    }
+
+    internal static double GetRadian(Point point1, Point point2)
+    {
+        return Math.Atan2(point2.Y - point1.Y, point2.X - point1.X);
+    }
+
+    // rect は relativeTo の (上、右、下、左) に配置されます。
+    internal static RelativeLocation GetRelativeLocation(Rect relativeTo, Rect rect)
+    {
+        var topLeftToBtmRight = GetRadian(relativeTo.TopLeft, relativeTo.BottomRight);
+        var btmLeftToTopRight = -topLeftToBtmRight;
+        var topRightToBtmLeft = Math.PI - topLeftToBtmRight;
+        var btmRightToTopLeft = -topRightToBtmLeft;
+
+        var radian = GetRadian(relativeTo.Center, rect.Center);
+
+        if (btmLeftToTopRight < radian && radian < topLeftToBtmRight)
+        {
+            return RelativeLocation.Right;
+        }
+        else if (topLeftToBtmRight < radian && radian < topRightToBtmLeft)
+        {
+            return RelativeLocation.Below;
+        }
+        else if (topRightToBtmLeft < radian && btmRightToTopLeft < radian)
+        {
+            return RelativeLocation.Left;
+        }
+        else if (btmRightToTopLeft < radian && radian < btmLeftToTopRight)
+        {
+            return RelativeLocation.Above;
+        }
+        else
+        {
+            throw new InvalidOperationException();
+        }
+    }
+
+    internal static Rect AbsoluteBounds(this Layoutable layoutable)
+    {
+        var destinationBounds = layoutable.Bounds;
+        var root = layoutable.GetVisualRoot()!;
+        var topLeft = layoutable.TranslatePoint(default, root);
+        var bottomRight = layoutable.TranslatePoint(new Point(destinationBounds.Width, destinationBounds.Height), root);
+
+        if (topLeft.HasValue && bottomRight.HasValue)
+        {
+            return new Rect(topLeft.Value, bottomRight.Value);
+        }
+        else
+        {
+            return Rect.Empty;
+        }
     }
 }

--- a/Avalonia.ConnectedAnimation/Helper.cs
+++ b/Avalonia.ConnectedAnimation/Helper.cs
@@ -39,10 +39,10 @@ public static class Helper
         {
             return AnimationDirection.None;
         }
-        else if (sourceCenter.X > destinationCenter.X)
+        else if (sourceCenter.X < destinationCenter.X)
         {
             // 右に移動
-            if (sourceCenter.Y > destinationCenter.Y)
+            if (sourceCenter.Y < destinationCenter.Y)
             {
                 // 下に移動
                 return AnimationDirection.RightLower;
@@ -56,7 +56,7 @@ public static class Helper
         else
         {
             // 左に移動
-            if (sourceCenter.Y > destinationCenter.Y)
+            if (sourceCenter.Y < destinationCenter.Y)
             {
                 // 下に移動
                 return AnimationDirection.LeftLower;
@@ -130,5 +130,10 @@ public static class Helper
         {
             return Rect.Empty;
         }
+    }
+
+    internal static System.Numerics.Vector2 ToVector2(this Point point)
+    {
+        return new System.Numerics.Vector2((float)point.X, (float)point.Y);
     }
 }

--- a/Avalonia.ConnectedAnimation/ICurve.cs
+++ b/Avalonia.ConnectedAnimation/ICurve.cs
@@ -1,0 +1,9 @@
+﻿using Avalonia.Animation.Animators;
+using Avalonia.Animation.Easings;
+
+namespace Avalonia.ConnectedAnimation;
+
+public interface ICurve
+{
+    Vector CalculatePosition(Rect start, Rect end, double progress);
+}

--- a/Avalonia.ConnectedAnimation/LinearCurve.cs
+++ b/Avalonia.ConnectedAnimation/LinearCurve.cs
@@ -1,0 +1,12 @@
+﻿using Avalonia.Animation.Animators;
+using Avalonia.Animation.Easings;
+
+namespace Avalonia.ConnectedAnimation;
+
+public sealed class LinearCurve : ICurve
+{
+    public Vector CalculatePosition(Rect start, Rect end, double progress)
+    {
+        return ((end.Position - start.Position) * progress) + start.Position;
+    }
+}

--- a/Avalonia.ConnectedAnimation/Properties/AssemblyInfo.cs
+++ b/Avalonia.ConnectedAnimation/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("SampleApp")]
+[assembly: InternalsVisibleTo("TestProject1")]

--- a/Avalonia.ConnectedAnimation/RelativeLocation.cs
+++ b/Avalonia.ConnectedAnimation/RelativeLocation.cs
@@ -1,0 +1,9 @@
+﻿namespace Avalonia.ConnectedAnimation;
+
+internal enum RelativeLocation
+{
+    Above,
+    Below,
+    Right,
+    Left,
+}

--- a/SampleApp/FirstPage.axaml.cs
+++ b/SampleApp/FirstPage.axaml.cs
@@ -65,6 +65,8 @@ public partial class FirstPage : UserControl, IPage
             && container is ListBoxItem item
             && item.Presenter is { Child: StackPanel child })
         {
+            avatarAnm.Configuration = new DirectConnectedAnimationConfiguration();
+
             var avatar = child.GetLogicalChildren().OfType<Image>().First(x => x.Name == "avatarImage");
             var name = child.GetLogicalChildren().OfType<TextBlock>().First(x => x.Name == "userName");
 

--- a/SampleApp/FirstPage.axaml.cs
+++ b/SampleApp/FirstPage.axaml.cs
@@ -61,14 +61,15 @@ public partial class FirstPage : UserControl, IPage
         var anm = ConnectedAnimationService.GetForCurrentView(this);
         ConnectedAnimation? avatarAnm = anm.GetAnimation("avatarImage");
         ConnectedAnimation? userNameAnm = anm.GetAnimation("userName");
-        if (avatarAnm != null && userNameAnm != null
+        if (avatarAnm != null /*&& userNameAnm != null*/
             && container is ListBoxItem item
             && item.Presenter is { Child: StackPanel child })
         {
             var avatar = child.GetLogicalChildren().OfType<Image>().First(x => x.Name == "avatarImage");
             var name = child.GetLogicalChildren().OfType<TextBlock>().First(x => x.Name == "userName");
 
-            await Task.WhenAll(avatarAnm.TryStart(avatar), userNameAnm.TryStart(name));
+            await avatarAnm.TryStart(avatar, new Control[] { name });
+            //await Task.WhenAll(avatarAnm.TryStart(avatar), userNameAnm.TryStart(name));
         }
         else
         {
@@ -88,9 +89,9 @@ public partial class FirstPage : UserControl, IPage
                 && item.Presenter is { Child: StackPanel child })
             {
                 var avatar = child.GetLogicalChildren().OfType<Image>().First(x => x.Name == "avatarImage");
-                var name = child.GetLogicalChildren().OfType<TextBlock>().First(x => x.Name == "userName");
+                //var name = child.GetLogicalChildren().OfType<TextBlock>().First(x => x.Name == "userName");
                 anm.PrepareToAnimate("avatarImage", avatar);
-                anm.PrepareToAnimate("userName", name);
+                //anm.PrepareToAnimate("userName", name);
             }
         }
     }

--- a/SampleApp/SecondPage.axaml
+++ b/SampleApp/SecondPage.axaml
@@ -10,7 +10,7 @@
              d:DesignHeight="450"
              d:DesignWidth="800"
              mc:Ignorable="d">
-    <StackPanel HorizontalAlignment="Center"
+    <!--<StackPanel HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 Spacing="8">
         <Image Name="avatarImage"
@@ -23,5 +23,22 @@
                    FontSize="24"
                    FontWeight="SemiBold"
                    Text="{Binding Name}" />
-    </StackPanel>
+    </StackPanel>-->
+    <Grid Margin="16" ColumnDefinitions="Auto,*">
+        <Image Name="avatarImage"
+               Width="120"
+               Height="120"
+               HorizontalAlignment="Left"
+               VerticalAlignment="Top"
+               asyncImageLoader:ImageLoader.Source="{Binding Avatar}" />
+
+        <TextBlock Name="userName"
+                   Grid.Column="1"
+                   Margin="16,0"
+                   HorizontalAlignment="Left"
+                   VerticalAlignment="Top"
+                   FontSize="24"
+                   FontWeight="SemiBold"
+                   Text="{Binding Name}" />
+    </Grid>
 </UserControl>

--- a/SampleApp/SecondPage.axaml.cs
+++ b/SampleApp/SecondPage.axaml.cs
@@ -19,7 +19,7 @@ public partial class SecondPage : UserControl, IPage
     {
         DataContext = args.Parameter;
         // Without this dispatch, the size of the TextBlock will be Stretched.
-        await Dispatcher.UIThread.InvokeAsync(() => { }, DispatcherPriority.Layout);
+        await Dispatcher.UIThread.InvokeAsync(() => { });
 
         var anm = ConnectedAnimationService.GetForCurrentView(this);
         ConnectedAnimation? avatarAnm = anm.GetAnimation("avatarImage");

--- a/SampleApp/SecondPage.axaml.cs
+++ b/SampleApp/SecondPage.axaml.cs
@@ -24,14 +24,15 @@ public partial class SecondPage : UserControl, IPage
         var anm = ConnectedAnimationService.GetForCurrentView(this);
         ConnectedAnimation? avatarAnm = anm.GetAnimation("avatarImage");
         ConnectedAnimation? userNameAnm = anm.GetAnimation("userName");
-        if (avatarAnm != null && userNameAnm != null)
+        if (avatarAnm != null /*&& userNameAnm != null*/)
         {
-            await Task.WhenAll(avatarAnm.TryStart(avatarImage), userNameAnm.TryStart(userName));
+            await avatarAnm.TryStart(avatarImage, new Control[] { userName });
+            //await Task.WhenAll(avatarAnm.TryStart(avatarImage), userNameAnm.TryStart(userName));
         }
         else
         {
             avatarAnm?.Cancel();
-            userNameAnm?.Cancel();
+            //userNameAnm?.Cancel();
         }
     }
 
@@ -39,6 +40,6 @@ public partial class SecondPage : UserControl, IPage
     {
         var anm = ConnectedAnimationService.GetForCurrentView(this);
         anm.PrepareToAnimate("avatarImage", avatarImage);
-        anm.PrepareToAnimate("userName", userName);
+        //anm.PrepareToAnimate("userName", userName);
     }
 }

--- a/TestProject1/TestProject1.csproj
+++ b/TestProject1/TestProject1.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Avalonia.ConnectedAnimation\Avalonia.ConnectedAnimation.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestProject1/UnitTest1.cs
+++ b/TestProject1/UnitTest1.cs
@@ -1,0 +1,56 @@
+using Avalonia;
+using Avalonia.ConnectedAnimation;
+
+namespace TestProject1;
+
+public class Tests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void Above()
+    {
+        var expect = RelativeLocation.Above;
+        var actual = Helper.GetRelativeLocation(
+            new Rect(70, 374, 60, 60),
+            new Rect(50, 50, 150, 100));
+
+        Assert.That(actual, Is.EqualTo(expect));
+    }
+    
+    [Test]
+    public void Below()
+    {
+        var expect = RelativeLocation.Below;
+        var actual = Helper.GetRelativeLocation(
+            new Rect(50, 50, 150, 100),
+            new Rect(70, 374, 60, 60));
+
+        Assert.That(actual, Is.EqualTo(expect));
+    }
+    
+    [Test]
+    public void Right()
+    {
+        var expect = RelativeLocation.Right;
+        var actual = Helper.GetRelativeLocation(
+            new Rect(50, 50, 150, 100),
+            new Rect(374, 70, 60, 60));
+
+        Assert.That(actual, Is.EqualTo(expect));
+    }
+
+    [Test]
+    public void Left()
+    {
+        var expect = RelativeLocation.Left;
+        var actual = Helper.GetRelativeLocation(
+            new Rect(374, 70, 60, 60),
+            new Rect(50, 50, 150, 100));
+
+        Assert.That(actual, Is.EqualTo(expect));
+    }
+}

--- a/TestProject1/Usings.cs
+++ b/TestProject1/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;


### PR DESCRIPTION
### 連動型アニメーション
`ConnectedAnimation.TryStart(Control, IEnumerable<Control>)` の
`coordinatedElements` 引数にコントロールを指定すると連動して表示するようになります。
https://learn.microsoft.com/en-us/windows/apps/design/motion/connected-animation#coordinated-animation

### ConnectedAnimationConfiguration
- GravityConnectedAnimationConfiguration
- DirectConnectedAnimationConfiguration
- BasicConnectedAnimationConfiguration

以下をご覧ください。
https://learn.microsoft.com/en-us/windows/apps/design/motion/connected-animation#connectedanimationservice-configuration